### PR TITLE
Automatically add type conversions around wrapped types

### DIFF
--- a/codegen/build.go
+++ b/codegen/build.go
@@ -35,9 +35,9 @@ func Bind(schema *schema.Schema, userTypes map[string]string, destDir string) (*
 
 	b := &Build{
 		PackageName: filepath.Base(destDir),
-		Objects:     buildObjects(namedTypes, schema, prog),
+		Objects:     buildObjects(namedTypes, schema, prog, imports),
 		Interfaces:  buildInterfaces(namedTypes, schema),
-		Inputs:      buildInputs(namedTypes, schema, prog),
+		Inputs:      buildInputs(namedTypes, schema, prog, imports),
 		Imports:     imports,
 	}
 
@@ -56,19 +56,19 @@ func Bind(schema *schema.Schema, userTypes map[string]string, destDir string) (*
 	// Poke a few magic methods into query
 	q := b.Objects.ByName(b.QueryRoot.GQLType)
 	q.Fields = append(q.Fields, Field{
-		Type:         &Type{namedTypes["__Schema"], []string{modPtr}},
+		Type:         &Type{namedTypes["__Schema"], []string{modPtr}, ""},
 		GQLName:      "__schema",
 		NoErr:        true,
 		GoMethodName: "ec.introspectSchema",
 		Object:       q,
 	})
 	q.Fields = append(q.Fields, Field{
-		Type:         &Type{namedTypes["__Type"], []string{modPtr}},
+		Type:         &Type{namedTypes["__Type"], []string{modPtr}, ""},
 		GQLName:      "__type",
 		NoErr:        true,
 		GoMethodName: "ec.introspectType",
 		Args: []FieldArgument{
-			{GQLName: "name", Type: &Type{namedTypes["String"], []string{}}},
+			{GQLName: "name", Type: &Type{namedTypes["String"], []string{}, ""}},
 		},
 		Object: q,
 	})

--- a/codegen/input_build.go
+++ b/codegen/input_build.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/tools/go/loader"
 )
 
-func buildInputs(namedTypes NamedTypes, s *schema.Schema, prog *loader.Program) Objects {
+func buildInputs(namedTypes NamedTypes, s *schema.Schema, prog *loader.Program, imports Imports) Objects {
 	var inputs Objects
 
 	for _, typ := range s.Types {
@@ -25,7 +25,7 @@ func buildInputs(namedTypes NamedTypes, s *schema.Schema, prog *loader.Program) 
 			}
 			if def != nil {
 				input.Marshaler = buildInputMarshaler(typ, def)
-				bindObject(def.Type(), input)
+				bindObject(def.Type(), input, imports)
 			}
 
 			inputs = append(inputs, input)

--- a/codegen/object.go
+++ b/codegen/object.go
@@ -38,15 +38,6 @@ type FieldArgument struct {
 
 type Objects []*Object
 
-func (o *Object) GetField(name string) *Field {
-	for i, field := range o.Fields {
-		if strings.EqualFold(field.GQLName, name) {
-			return &o.Fields[i]
-		}
-	}
-	return nil
-}
-
 func (o *Object) Implementors() string {
 	satisfiedBy := strconv.Quote(o.GQLType)
 	for _, s := range o.Satisfies {

--- a/codegen/object_build.go
+++ b/codegen/object_build.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/tools/go/loader"
 )
 
-func buildObjects(types NamedTypes, s *schema.Schema, prog *loader.Program) Objects {
+func buildObjects(types NamedTypes, s *schema.Schema, prog *loader.Program, imports Imports) Objects {
 	var objects Objects
 
 	for _, typ := range s.Types {
@@ -23,7 +23,7 @@ func buildObjects(types NamedTypes, s *schema.Schema, prog *loader.Program) Obje
 				fmt.Fprintf(os.Stderr, err.Error())
 			}
 			if def != nil {
-				bindObject(def.Type(), obj)
+				bindObject(def.Type(), obj, imports)
 			}
 
 			objects = append(objects, obj)

--- a/example/scalars/generated.go
+++ b/example/scalars/generated.go
@@ -218,6 +218,14 @@ func (ec *executionContext) _user(sel []query.Selection, it *User) graphql.Marsh
 			res := it.Location
 
 			out.Values[i] = res
+		case "isBanned":
+			badArgs := false
+			if badArgs {
+				continue
+			}
+			res := it.IsBanned
+
+			out.Values[i] = graphql.MarshalBoolean(bool(res))
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -807,13 +815,20 @@ func UnmarshalSearchArgs(v interface{}) (SearchArgs, error) {
 				return it, err
 			}
 			it.CreatedAfter = &val
+		case "isBanned":
+			castTmp, err := graphql.UnmarshalBoolean(v)
+			val := Banned(castTmp)
+			if err != nil {
+				return it, err
+			}
+			it.IsBanned = val
 		}
 	}
 
 	return it, nil
 }
 
-var parsedSchema = schema.MustParse("schema {\n    query: Query\n}\n\ntype Query {\n    user(id: ID!): User\n    search(input: SearchArgs!): [User!]!\n}\n\ntype User {\n    id: ID!\n    name: String!\n    created: Timestamp\n    location: Point\n}\n\ninput SearchArgs {\n    location: Point\n    createdAfter: Timestamp\n}\n\nscalar Timestamp\nscalar Point\n")
+var parsedSchema = schema.MustParse("schema {\n    query: Query\n}\n\ntype Query {\n    user(id: ID!): User\n    search(input: SearchArgs!): [User!]!\n}\n\ntype User {\n    id: ID!\n    name: String!\n    created: Timestamp\n    location: Point\n    isBanned: Boolean!\n}\n\ninput SearchArgs {\n    location: Point\n    createdAfter: Timestamp\n    isBanned: Boolean\n}\n\nscalar Timestamp\nscalar Point\n")
 
 func (ec *executionContext) introspectSchema() *introspection.Schema {
 	return introspection.WrapSchema(parsedSchema)

--- a/example/scalars/model.go
+++ b/example/scalars/model.go
@@ -11,11 +11,14 @@ import (
 	"github.com/vektah/gqlgen/graphql"
 )
 
+type Banned bool
+
 type User struct {
 	ID       string
 	Name     string
 	Location Point     // custom scalar types
 	Created  time.Time // direct binding to builtin types with external Marshal/Unmarshal methods
+	IsBanned Banned    // aliased primitive
 }
 
 // Point is serialized as a simple array, eg [1, 2]
@@ -71,4 +74,5 @@ func UnmarshalTimestamp(v interface{}) (time.Time, error) {
 type SearchArgs struct {
 	Location     *Point
 	CreatedAfter *time.Time
+	IsBanned     Banned
 }

--- a/example/scalars/schema.graphql
+++ b/example/scalars/schema.graphql
@@ -12,11 +12,13 @@ type User {
     name: String!
     created: Timestamp
     location: Point
+    isBanned: Boolean!
 }
 
 input SearchArgs {
     location: Point
     createdAfter: Timestamp
+    isBanned: Boolean
 }
 
 scalar Timestamp

--- a/example/starwars/model.go
+++ b/example/starwars/model.go
@@ -33,7 +33,7 @@ func (h *Human) Height(unit string) float64 {
 type Starship struct {
 	ID           string
 	Name         string
-	History      [][2]int
+	History      [][]int
 	lengthMeters float64
 }
 

--- a/example/starwars/resolvers.go
+++ b/example/starwars/resolvers.go
@@ -223,7 +223,7 @@ func NewResolver() *Resolver {
 		"3000": {
 			ID:   "3000",
 			Name: "Millennium Falcon",
-			History: [][2]int{
+			History: [][]int{
 				{1, 2},
 				{4, 5},
 				{1, 2},
@@ -234,7 +234,7 @@ func NewResolver() *Resolver {
 		"3001": {
 			ID:   "3001",
 			Name: "X-Wing",
-			History: [][2]int{
+			History: [][]int{
 				{6, 4},
 				{3, 2},
 				{2, 3},
@@ -245,7 +245,7 @@ func NewResolver() *Resolver {
 		"3002": {
 			ID:   "3002",
 			Name: "TIE Advanced x1",
-			History: [][2]int{
+			History: [][]int{
 				{3, 2},
 				{7, 2},
 				{6, 4},
@@ -256,7 +256,7 @@ func NewResolver() *Resolver {
 		"3003": {
 			ID:   "3003",
 			Name: "Imperial shuttle",
-			History: [][2]int{
+			History: [][]int{
 				{1, 7},
 				{3, 5},
 				{5, 3},


### PR DESCRIPTION
Given a primitive type in the schema
```graphql schema
type User {
    isBanned: Boolean!
}
```
being bound to a wrapped primitive in go
```go
type MyBool bool

type User struct {
    IsBanned MyBool
}
```

generate the appropriate type conversion automatically in the bindings.

Fixes https://github.com/vektah/gqlgen/issues/12