### PR TITLE
Add map[string]interface{} escape hatch

### DIFF
--- a/codegen/type.go
+++ b/codegen/type.go
@@ -126,7 +126,9 @@ func (t Type) unmarshal(result, raw string, remainingMods []string, depth int) s
 	return tpl(`{{- if .t.CastType }}
 			var castTmp {{.t.FullName}}
 		{{ end }}
-			{{- if .t.Marshaler }}
+			{{- if eq .t.GoType "map[string]interface{}" }}
+				{{- .result }} = {{.raw}}.(map[string]interface{})
+			{{- else if .t.Marshaler }}
 				{{- .result }}, err = {{ .t.Marshaler.PkgDot }}Unmarshal{{.t.Marshaler.GoType}}({{.raw}})
 			{{- else -}}
 				err = (&{{.result}}).UnmarshalGQL({{.raw}})

--- a/example/todo/generated.go
+++ b/example/todo/generated.go
@@ -128,7 +128,7 @@ func (ec *executionContext) _MyMutation_updateTodo(field graphql.CollectedField)
 	var arg1 map[string]interface{}
 	if tmp, ok := field.Args["changes"]; ok {
 		var err error
-		arg1, err = graphql.UnmarshalMap(tmp)
+		arg1 = tmp.(map[string]interface{})
 		if err != nil {
 			ec.Error(err)
 			return graphql.Null

--- a/test/schema.graphql
+++ b/test/schema.graphql
@@ -35,9 +35,15 @@ input RecursiveInputSlice {
 
 union ShapeUnion = Circle | Rectangle
 
+input Changes {
+    a: Int
+    b: Int
+}
+
 type Query {
     nestedInputs(input: [[OuterInput]] = [[{inner: {id: 1}}]]): Boolean
     nestedOutputs: [[OuterObject]]
     shapes: [Shape]
     recursive(input: RecursiveInputSlice): Boolean
+    mapInput(input: Changes): Boolean
 }

--- a/test/types.json
+++ b/test/types.json
@@ -3,5 +3,6 @@
     "ShapeUnion": "github.com/vektah/gqlgen/test.ShapeUnion",
     "Circle": "github.com/vektah/gqlgen/test.Circle",
     "Rectangle": "github.com/vektah/gqlgen/test.Rectangle",
-    "RecursiveInputSlice": "github.com/vektah/gqlgen/test.RecursiveInputSlice"
+    "RecursiveInputSlice": "github.com/vektah/gqlgen/test.RecursiveInputSlice",
+    "Changes": "map[string]interface{}"
 }


### PR DESCRIPTION
Add the ability to specify `map[string]interface{}` in types.json to get the raw input map. Necessary when you need to distinguish undefined from null, eg change sets.