### PR TITLE
fix package paths on windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,13 +141,13 @@ func fullPackageName(file string, override string) string {
 		pkgName = filepath.Join(filepath.Dir(pkgName), override)
 	}
 
-	for _, gopath := range strings.Split(build.Default.GOPATH, ":") {
-		gopath += "/src/"
+	for _, gopath := range filepath.SplitList(build.Default.GOPATH) {
+		gopath = filepath.Join(gopath, "src") + string(os.PathSeparator)
 		if strings.HasPrefix(pkgName, gopath) {
 			pkgName = pkgName[len(gopath):]
 		}
 	}
-	return pkgName
+	return filepath.ToSlash(pkgName)
 }
 
 func dirName(path string) string {


### PR DESCRIPTION
Hello,

I wasn't able to run gqlgen on windows due to a rather cryptic error:

```
cannot find package "C:\\Users\\jonwa\\go\\src\\gitlab.com\\***\\backend\\dashboard\\internal\\graph" in any of:
	C:\Users\jonwa\go\src\gitlab.com\***\vendor\C:\Users\jonwa\go\src\gitlab.com\***\backend\dashboard\internal\graph (vendor tree)
	C:\Go\src\C:\Users\jonwa\go\src\gitlab.com\***\backend\dashboard\internal\graph (from $GOROOT)
	C:\Users\jonwa\go\src\C:\Users\jonwa\go\src\gitlab.com\***\backend\dashboard\internal\graph (from $GOPATH)
failed to generate code: couldn't load packages due to errors: C:\Users\jonwa\go\src\gitlab.com\***\backend\dashboard\internal\graph
rootResolver.go:1: running "gorunpkg": exit status 1

Process finished with exit code 1
```

this was due to the `gopath` splitting using unix separators and `gopath += "/src/"` resulted in gopath being set to `c:\Users\jonwa\go/src/` so the package name didn't get set correctly.

not sure what you want to do with the error. it's rather cryptic (passed straight from go's loader) but once you remember the package is `gitlab.com\\***\\backend\\dashboard\\internal\\graph` and not `C:\\Users\\jonwa\\go\\src\\gitlab.com\\***\\backend\\dashboard\\internal\\graph` it makes sense