### PR TITLE
Fix vendor normalization

### DIFF
--- a/codegen/type_build.go
+++ b/codegen/type_build.go
@@ -76,11 +76,6 @@ func pkgAndType(name string) (string, string) {
 	return normalizeVendor(strings.Join(parts[:len(parts)-1], ".")), parts[len(parts)-1]
 }
 
-func normalizeVendor(pkg string) string {
-	parts := strings.Split(pkg, "/vendor/")
-	return parts[len(parts)-1]
-}
-
 func (n NamedTypes) getType(t common.Type) *Type {
 	var modifiers []string
 	usePtr := true

--- a/codegen/util.go
+++ b/codegen/util.go
@@ -2,6 +2,7 @@ package codegen
 
 import (
 	"go/types"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -176,7 +177,7 @@ func bindObject(t types.Type, object *Object, imports Imports) error {
 			field.Type.Modifiers = modifiersFromGoType(structField.Type())
 			field.GoVarName = structField.Name()
 
-			switch field.Type.FullSignature() {
+			switch normalizeVendor(field.Type.FullSignature()) {
 			case normalizeVendor(structField.Type().String()):
 				// everything is fine
 
@@ -214,4 +215,13 @@ func modifiersFromGoType(t types.Type) []string {
 			return modifiers
 		}
 	}
+}
+
+var modsRegex = regexp.MustCompile(`^(\*|\[\])*`)
+
+func normalizeVendor(pkg string) string {
+	modifiers := modsRegex.FindAllString(pkg, 1)[0]
+	pkg = strings.TrimPrefix(pkg, modifiers)
+	parts := strings.Split(pkg, "/vendor/")
+	return modifiers + parts[len(parts)-1]
 }

--- a/codegen/util_test.go
+++ b/codegen/util_test.go
@@ -1,0 +1,14 @@
+package codegen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeVendor(t *testing.T) {
+	require.Equal(t, "bar/baz", normalizeVendor("foo/vendor/bar/baz"))
+	require.Equal(t, "[]bar/baz", normalizeVendor("[]foo/vendor/bar/baz"))
+	require.Equal(t, "*bar/baz", normalizeVendor("*foo/vendor/bar/baz"))
+	require.Equal(t, "*[]*bar/baz", normalizeVendor("*[]*foo/vendor/bar/baz"))
+}

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"remote_api"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -83,6 +85,12 @@ func TestInputDefaults(t *testing.T) {
 type testResolvers struct {
 	err       error
 	queryDate func(ctx context.Context, filter models.DateFilter) (bool, error)
+}
+
+func (r *testResolvers) Query_viewer(ctx context.Context) (*Viewer, error) {
+	return &Viewer{
+		User: &remote_api.User{"Bob"},
+	}, nil
 }
 
 func (r *testResolvers) Query_date(ctx context.Context, filter models.DateFilter) (bool, error) {

--- a/test/schema.graphql
+++ b/test/schema.graphql
@@ -18,7 +18,15 @@ input DateFilter {
     op: DATE_FILTER_OP = EQ
 }
 
+type User {
+    name: String
+}
+type Viewer {
+    user: User
+}
+
 type Query {
     path: [Element]
     date(filter: DateFilter!): Boolean!
+    viewer: Viewer
 }

--- a/test/types.json
+++ b/test/types.json
@@ -1,3 +1,5 @@
 {
-    "Element": "github.com/vektah/gqlgen/test.Element"
+    "Element": "github.com/vektah/gqlgen/test.Element",
+    "Viewer": "github.com/vektah/gqlgen/test.Viewer",
+    "User": "remote_api.User"
 }

--- a/test/vendor/remote_api/user.go
+++ b/test/vendor/remote_api/user.go
@@ -1,0 +1,5 @@
+package remote_api
+
+type User struct {
+	Name string
+}

--- a/test/viewer.go
+++ b/test/viewer.go
@@ -1,0 +1,7 @@
+package test
+
+import "remote_api"
+
+type Viewer struct {
+	User *remote_api.User
+}


### PR DESCRIPTION
When refering to vendored types in fields a type assertion would fail. This
PR makes sure that both paths are normalized to not include the vendor
directory.