### PR TITLE
convert windows input path separators to slash

### DIFF
--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -89,7 +89,7 @@ func (cfg *Config) normalize() error {
 		return errors.New("ModelFilename is required")
 	}
 	cfg.ModelFilename = abs(cfg.ModelFilename)
-	cfg.modelDir = filepath.Dir(cfg.ModelFilename)
+	cfg.modelDir = filepath.ToSlash(filepath.Dir(cfg.ModelFilename))
 	if cfg.ModelPackageName == "" {
 		cfg.ModelPackageName = filepath.Base(cfg.modelDir)
 	}
@@ -100,7 +100,7 @@ func (cfg *Config) normalize() error {
 		return errors.New("ModelFilename is required")
 	}
 	cfg.ExecFilename = abs(cfg.ExecFilename)
-	cfg.execDir = filepath.Dir(cfg.ExecFilename)
+	cfg.execDir = filepath.ToSlash(filepath.Dir(cfg.ExecFilename))
 	if cfg.ExecPackageName == "" {
 		cfg.ExecPackageName = filepath.Base(cfg.execDir)
 	}
@@ -141,7 +141,7 @@ func abs(path string) string {
 	if err != nil {
 		panic(err)
 	}
-	return absPath
+	return filepath.ToSlash(absPath)
 }
 
 func fullPackageName(dir string, pkgName string) string {


### PR DESCRIPTION
I found recently that generating from windows was causing circular imports within `generated.go`. looks like we had another case of windows file path issues.

this feels a bit hacky to me but thought i would start the discussion.

windows is able to use \ or / as a path separator. I'm not aware of any other (modern and supported ;) ) OS using \

one use case we might come across is the source files being on a UNC share which might be due to people using virtualbox etc and sharing the host's filesystem; not sure how likely that is, but anyway