### PR TITLE
skip struct fields with incompatible types

### DIFF
--- a/codegen/util.go
+++ b/codegen/util.go
@@ -174,6 +174,7 @@ func bindObject(t types.Type, object *Object, imports Imports) error {
 		}
 
 		if structField := findField(underlying, field.GQLName); structField != nil {
+			prevModifiers := field.Type.Modifiers
 			field.Type.Modifiers = modifiersFromGoType(structField.Type())
 			field.GoVarName = structField.Name()
 
@@ -190,7 +191,9 @@ func bindObject(t types.Type, object *Object, imports Imports) error {
 				}
 
 			default:
-				return errors.Errorf("type mismatch on %s.%s, expected %s got %s\n", object.GQLType, field.GQLName, field.Type.FullSignature(), structField.Type())
+				// type mismatch, require custom resolver for field
+				field.GoVarName = ""
+				field.Type.Modifiers = prevModifiers
 			}
 			continue
 		}


### PR DESCRIPTION
This PR changes the behavior of `bindObject` to ignore fields that cannot be automatically mapped from a struct. In the case of a type mismatch, the generated resolver will now require a method for the field, as if there were no matching field on the struct to begin with. This allows the logic for mapping field values to be provided as-needed, making cases like #82 hopefully easier to work with.

Previously this case would result in a fatal error (code gen would fail with a type mismatch error).

---

Example scenario (with this change):

Schema:
```graphql
type User {
  createdAt String
  listOfEnums [FooEnum]
  name String
}
enum FooEnum {
  bin, bar, baz
}
```

Application struct (mapped with `types.json`):
```go
type ListOfEnum []FooEnum
type User struct {
  Name string
  CreatedAt time.Time
  Foo ListOfEnum
}
```

Result:
```go
type Resolvers interface {
  User_createdAt(ctx context.Context, obj *user.User) (*string, error)
  User_listOfEnums(ctx context.Context, obj *user.User) ([]FooEnum, error)
}
```

One could then simply define `User_createdAt` to map `time.Time -> *string` and `User_listOfEnums` to map `ListOfEnum -> []FooEnum`.