### PR TITLE
Validate at end

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -3,7 +3,7 @@
   "Deadline": "5m",
   "Linters": {
     "errcheck": {
-      "Command":           "errcheck -abspath -ignore '[rR]ead|[wW]rite|Close'",
+      "Command":           "errcheck -abspath -ignore '[rR]ead|[wW]rite|Close|[fF]print'",
       "Pattern":           "PATH:LINE:COL:MESSAGE",
       "InstallFrom":       "github.com/kisielk/errcheck",
       "PartitionStrategy": "packages"

--- a/codegen/build.go
+++ b/codegen/build.go
@@ -57,7 +57,7 @@ func (cfg *Config) models() (*ModelBuild, error) {
 func (cfg *Config) bind() (*Build, error) {
 	namedTypes := cfg.buildNamedTypes()
 
-	prog, err := cfg.loadProgram(namedTypes, false)
+	prog, err := cfg.loadProgram(namedTypes, true)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading failed")
 	}
@@ -120,6 +120,13 @@ func (cfg *Config) bind() (*Build, error) {
 	})
 
 	return b, nil
+}
+
+func (cfg *Config) validate() error {
+	namedTypes := cfg.buildNamedTypes()
+
+	_, err := cfg.loadProgram(namedTypes, false)
+	return err
 }
 
 func (cfg *Config) loadProgram(namedTypes NamedTypes, allowErrors bool) (*loader.Program, error) {

--- a/codegen/codegen.go
+++ b/codegen/codegen.go
@@ -82,6 +82,11 @@ func Generate(cfg Config) error {
 	if err = write(cfg.ExecFilename, buf.Bytes()); err != nil {
 		return err
 	}
+
+	if err = cfg.validate(); err != nil {
+		return errors.Wrap(err, "validation failed")
+	}
+
 	return nil
 }
 

--- a/example/todo/server/server.go
+++ b/example/todo/server/server.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	http.Handle("/", handler.Playground("Todo", "/query"))
 	http.Handle("/query", handler.GraphQL(
-		todo.MakeExecutableSchema(todo.New()),
+		todo.NewExecutableSchema(todo.New()),
 		handler.RecoverFunc(func(ctx context.Context, err interface{}) error {
 			// send this panic somewhere
 			log.Print(err)

--- a/example/todo/todo_test.go
+++ b/example/todo/todo_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestTodo(t *testing.T) {
-	srv := httptest.NewServer(handler.GraphQL(MakeExecutableSchema(New())))
+	srv := httptest.NewServer(handler.GraphQL(NewExecutableSchema(New())))
 	c := client.New(srv.URL)
 
 	t.Run("create a new todo", func(t *testing.T) {


### PR DESCRIPTION
When loading the program during codegen allow errors and try to generate, assuming these errors wont affect codegen. Once the code has been generated, validate the program a second time and show those errors. Any error here may have affected codegen (eg if the thing you were trying to bind to had invalid code resolvers would have been generated instead of binding directly)

Alternative to #160
Fixes #152