### PR TITLE
Add docs for error handling

### DIFF
--- a/docs/content/reference/errors.md
+++ b/docs/content/reference/errors.md
@@ -1,0 +1,33 @@
+---
+linkTitle: Handling Errors
+title: Sending custom error data in the graphql response
+description: Customising graphql error types to send custom error data back to the client using gqlgen.
+menu: main
+---
+
+All errors raised by gqlgen pass through a hook before being displayed to the user. This hook gives you the ability to
+customize errors however makes sense in your app.
+
+
+You can set it when creating the handler:
+```go
+server := handler.GraphQL(MakeExecutableSchema(resolvers),
+	handler.ErrorPresenter(
+		func(ctx context.Context, e error) graphql.MarshalableError {
+			// any special logic you want to do here. This only
+			// requirement is that it can be json encoded
+			if myError, ok := e.(MyError) ; ok {
+				return e
+			}
+
+			return graphql.DefaultErrorPresenter(ctx, e)
+		}
+	),
+)
+```
+
+This function is called in a defer, so the stack is still at the right location and you have access to context to get
+the current resolver path. By customizing the result you can add custom properties to errors, or implement your own
+error type that is passed directly through to the client.
+
+

--- a/graphql/errors_test.go
+++ b/graphql/errors_test.go
@@ -17,8 +17,8 @@ func TestBuilder_Error(t *testing.T) {
 	})
 
 	require.Len(t, b.Errors, 2)
-	assert.EqualError(t, b.Errors[0], "err1")
-	assert.EqualError(t, b.Errors[1], "err2 public")
+	assert.Equal(t, b.Errors[0], &ResolverError{Message: "err1"})
+	assert.Equal(t, b.Errors[1], &ResolverError{Message: "err2 public"})
 }
 
 type testErr struct {
@@ -42,7 +42,7 @@ func (err *publicErr) PublicError() string {
 	return err.public
 }
 
-func convertErr(ctx context.Context, err error) error {
+func convertErr(ctx context.Context, err error) MarshalableError {
 	if errConv, ok := err.(*publicErr); ok {
 		return &ResolverError{Message: errConv.public}
 	}

--- a/graphql/response.go
+++ b/graphql/response.go
@@ -7,12 +7,12 @@ import (
 )
 
 type Response struct {
-	Data   json.RawMessage `json:"data"`
-	Errors []error         `json:"errors,omitempty"`
+	Data   json.RawMessage    `json:"data"`
+	Errors []MarshalableError `json:"errors,omitempty"`
 }
 
 func ErrorResponse(ctx context.Context, messagef string, args ...interface{}) *Response {
 	return &Response{
-		Errors: []error{&ResolverError{Message: fmt.Sprintf(messagef, args...)}},
+		Errors: []MarshalableError{&ResolverError{Message: fmt.Sprintf(messagef, args...)}},
 	}
 }

--- a/handler/graphql.go
+++ b/handler/graphql.go
@@ -206,7 +206,7 @@ func GraphQL(exec graphql.ExecutableSchema, options ...Option) http.HandlerFunc 
 
 func sendError(w http.ResponseWriter, code int, errors ...*errors.QueryError) {
 	w.WriteHeader(code)
-	var errs []error
+	var errs []graphql.MarshalableError
 	for _, err := range errors {
 		errs = append(errs, err)
 	}

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -23,7 +23,7 @@ import (
 func TestCustomErrorPresenter(t *testing.T) {
 	resolvers := &testResolvers{}
 	srv := httptest.NewServer(handler.GraphQL(MakeExecutableSchema(resolvers),
-		handler.ErrorPresenter(func(i context.Context, e error) error {
+		handler.ErrorPresenter(func(i context.Context, e error) graphql.MarshalableError {
 			if _, ok := errors.Cause(e).(*specialErr); ok {
 				return &graphql.ResolverError{Message: "override special error message"}
 			}


### PR DESCRIPTION
I cleaned up the return type from the Error presenter to try and better document the intent behind that function. Its really not returning an `error`, its returning an `interface{}` to be json marshaled.

Closes #174 