### PR TITLE
Allowing for resolvers to return multiple errors to errorbuilder

### DIFF
--- a/graphql/error.go
+++ b/graphql/error.go
@@ -26,6 +26,11 @@ func (r *ResolverError) Error() string {
 	return r.Message
 }
 
+type Errors interface {
+	Errors() []error
+	Error() string
+}
+
 type ErrorBuilder struct {
 	Errors []error
 	// ErrorPresenter will be used to generate the error
@@ -45,5 +50,12 @@ func (c *ErrorBuilder) Error(ctx context.Context, err error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.Errors = append(c.Errors, c.ErrorPresenter(ctx, err))
+	switch err := err.(type) {
+	case Errors:
+		for _, err := range err.Errors() {
+			c.Errors = append(c.Errors, c.ErrorPresenter(ctx, err))
+		}
+	default:
+		c.Errors = append(c.Errors, c.ErrorPresenter(ctx, err))
+	}
 }


### PR DESCRIPTION
Attempting to fix #141 by allowing you to pass an error that includes an `Errors()` function.

Maybe not the nicest solution as it requires a lot of work from the consumer's point of view, but this gets people unblocked in the meantime.

In the future, I'd want to see the `ErrorBuilder`or even the `graphql.Response` opened up to some kind of formatter somehow.