### PR TITLE
validate method return types

### DIFF
--- a/codegen/input_build.go
+++ b/codegen/input_build.go
@@ -27,9 +27,9 @@ func (cfg *Config) buildInputs(namedTypes NamedTypes, prog *loader.Program, impo
 			}
 			if def != nil {
 				input.Marshaler = buildInputMarshaler(typ, def)
-				err = bindObject(def.Type(), input, imports)
-				if err != nil {
-					return nil, err
+				bindErrs := bindObject(def.Type(), input, imports)
+				if len(bindErrs) > 0 {
+					return nil, bindErrs
 				}
 			}
 

--- a/codegen/object_build.go
+++ b/codegen/object_build.go
@@ -1,6 +1,7 @@
 package codegen
 
 import (
+	"log"
 	"sort"
 	"strings"
 
@@ -25,9 +26,9 @@ func (cfg *Config) buildObjects(types NamedTypes, prog *loader.Program, imports 
 				return nil, err
 			}
 			if def != nil {
-				err = bindObject(def.Type(), obj, imports)
-				if err != nil {
-					return nil, err
+				for _, bindErr := range bindObject(def.Type(), obj, imports) {
+					log.Println(bindErr.Error())
+					log.Println("  Adding resolver method")
 				}
 			}
 

--- a/codegen/testdata/recursive.go
+++ b/codegen/testdata/recursive.go
@@ -1,5 +1,5 @@
 package testdata
 
 type RecursiveInputSlice struct {
-	Self *[]*RecursiveInputSlice
+	Self []RecursiveInputSlice
 }

--- a/example/chat/generated.go
+++ b/example/chat/generated.go
@@ -595,10 +595,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -755,10 +752,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -772,10 +766,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.Type()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field graphql.CollectedField, obj *introspection.Field) graphql.Marshaler {
@@ -865,10 +856,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.Type()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField, obj *introspection.InputValue) graphql.Marshaler {
@@ -930,10 +918,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -947,10 +932,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.QueryType()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field graphql.CollectedField, obj *introspection.Schema) graphql.Marshaler {
@@ -995,10 +977,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Directive(ctx, field.Selections, res[idx1])
+			return ec.___Directive(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1107,10 +1086,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Field(ctx, field.Selections, res[idx1])
+			return ec.___Field(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1130,10 +1106,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1153,10 +1126,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1187,10 +1157,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___EnumValue(ctx, field.Selections, res[idx1])
+			return ec.___EnumValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1210,10 +1177,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1

--- a/example/dataloader/generated.go
+++ b/example/dataloader/generated.go
@@ -705,10 +705,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -865,10 +862,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -882,10 +876,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.Type()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field graphql.CollectedField, obj *introspection.Field) graphql.Marshaler {
@@ -975,10 +966,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.Type()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField, obj *introspection.InputValue) graphql.Marshaler {
@@ -1040,10 +1028,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1057,10 +1042,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.QueryType()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field graphql.CollectedField, obj *introspection.Schema) graphql.Marshaler {
@@ -1105,10 +1087,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Directive(ctx, field.Selections, res[idx1])
+			return ec.___Directive(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1217,10 +1196,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Field(ctx, field.Selections, res[idx1])
+			return ec.___Field(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1240,10 +1216,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1263,10 +1236,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1297,10 +1267,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___EnumValue(ctx, field.Selections, res[idx1])
+			return ec.___EnumValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1320,10 +1287,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1

--- a/example/scalars/generated.go
+++ b/example/scalars/generated.go
@@ -581,10 +581,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -741,10 +738,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -758,10 +752,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.Type()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field graphql.CollectedField, obj *introspection.Field) graphql.Marshaler {
@@ -851,10 +842,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.Type()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField, obj *introspection.InputValue) graphql.Marshaler {
@@ -916,10 +904,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -933,10 +918,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.QueryType()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field graphql.CollectedField, obj *introspection.Schema) graphql.Marshaler {
@@ -981,10 +963,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Directive(ctx, field.Selections, res[idx1])
+			return ec.___Directive(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1093,10 +1072,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Field(ctx, field.Selections, res[idx1])
+			return ec.___Field(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1116,10 +1092,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1139,10 +1112,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1173,10 +1143,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___EnumValue(ctx, field.Selections, res[idx1])
+			return ec.___EnumValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1196,10 +1163,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1

--- a/example/selection/generated.go
+++ b/example/selection/generated.go
@@ -460,10 +460,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -620,10 +617,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -637,10 +631,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.Type()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field graphql.CollectedField, obj *introspection.Field) graphql.Marshaler {
@@ -730,10 +721,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.Type()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField, obj *introspection.InputValue) graphql.Marshaler {
@@ -795,10 +783,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -812,10 +797,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.QueryType()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field graphql.CollectedField, obj *introspection.Schema) graphql.Marshaler {
@@ -860,10 +842,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Directive(ctx, field.Selections, res[idx1])
+			return ec.___Directive(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -972,10 +951,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Field(ctx, field.Selections, res[idx1])
+			return ec.___Field(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -995,10 +971,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1018,10 +991,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1052,10 +1022,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___EnumValue(ctx, field.Selections, res[idx1])
+			return ec.___EnumValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1075,10 +1042,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1

--- a/example/starwars/generated.go
+++ b/example/starwars/generated.go
@@ -1660,10 +1660,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1820,10 +1817,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1837,10 +1831,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.Type()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field graphql.CollectedField, obj *introspection.Field) graphql.Marshaler {
@@ -1930,10 +1921,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.Type()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField, obj *introspection.InputValue) graphql.Marshaler {
@@ -1995,10 +1983,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -2012,10 +1997,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.QueryType()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field graphql.CollectedField, obj *introspection.Schema) graphql.Marshaler {
@@ -2060,10 +2042,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Directive(ctx, field.Selections, res[idx1])
+			return ec.___Directive(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -2172,10 +2151,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Field(ctx, field.Selections, res[idx1])
+			return ec.___Field(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -2195,10 +2171,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -2218,10 +2191,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -2252,10 +2222,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___EnumValue(ctx, field.Selections, res[idx1])
+			return ec.___EnumValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -2275,10 +2242,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1

--- a/example/todo/generated.go
+++ b/example/todo/generated.go
@@ -563,10 +563,7 @@ func (ec *executionContext) ___Directive_args(ctx context.Context, field graphql
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -723,10 +720,7 @@ func (ec *executionContext) ___Field_args(ctx context.Context, field graphql.Col
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -740,10 +734,7 @@ func (ec *executionContext) ___Field_type(ctx context.Context, field graphql.Col
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.Type()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___Field_isDeprecated(ctx context.Context, field graphql.CollectedField, obj *introspection.Field) graphql.Marshaler {
@@ -833,10 +824,7 @@ func (ec *executionContext) ___InputValue_type(ctx context.Context, field graphq
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.Type()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___InputValue_defaultValue(ctx context.Context, field graphql.CollectedField, obj *introspection.InputValue) graphql.Marshaler {
@@ -898,10 +886,7 @@ func (ec *executionContext) ___Schema_types(ctx context.Context, field graphql.C
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -915,10 +900,7 @@ func (ec *executionContext) ___Schema_queryType(ctx context.Context, field graph
 	rctx.PushField(field.Alias)
 	defer rctx.Pop()
 	res := obj.QueryType()
-	if res == nil {
-		return graphql.Null
-	}
-	return ec.___Type(ctx, field.Selections, res)
+	return ec.___Type(ctx, field.Selections, &res)
 }
 
 func (ec *executionContext) ___Schema_mutationType(ctx context.Context, field graphql.CollectedField, obj *introspection.Schema) graphql.Marshaler {
@@ -963,10 +945,7 @@ func (ec *executionContext) ___Schema_directives(ctx context.Context, field grap
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Directive(ctx, field.Selections, res[idx1])
+			return ec.___Directive(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1075,10 +1054,7 @@ func (ec *executionContext) ___Type_fields(ctx context.Context, field graphql.Co
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Field(ctx, field.Selections, res[idx1])
+			return ec.___Field(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1098,10 +1074,7 @@ func (ec *executionContext) ___Type_interfaces(ctx context.Context, field graphq
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1121,10 +1094,7 @@ func (ec *executionContext) ___Type_possibleTypes(ctx context.Context, field gra
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___Type(ctx, field.Selections, res[idx1])
+			return ec.___Type(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1155,10 +1125,7 @@ func (ec *executionContext) ___Type_enumValues(ctx context.Context, field graphq
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___EnumValue(ctx, field.Selections, res[idx1])
+			return ec.___EnumValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1
@@ -1178,10 +1145,7 @@ func (ec *executionContext) ___Type_inputFields(ctx context.Context, field graph
 			rctx := graphql.GetResolverContext(ctx)
 			rctx.PushIndex(idx1)
 			defer rctx.Pop()
-			if res[idx1] == nil {
-				return graphql.Null
-			}
-			return ec.___InputValue(ctx, field.Selections, res[idx1])
+			return ec.___InputValue(ctx, field.Selections, &res[idx1])
 		}())
 	}
 	return arr1

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 
 	"github.com/vektah/gqlgen/codegen"
@@ -18,6 +19,7 @@ var typemap = flag.String("typemap", "", "a json map going from graphql to golan
 var packageName = flag.String("package", "", "the package name")
 var modelPackageName = flag.String("modelpackage", "", "the package name to use for models")
 var help = flag.Bool("h", false, "this usage text")
+var verbose = flag.Bool("v", false, "show logs")
 
 func main() {
 	flag.Usage = func() {
@@ -30,6 +32,11 @@ func main() {
 	if *help {
 		flag.Usage()
 		os.Exit(1)
+	}
+	if *verbose {
+		log.SetFlags(0)
+	} else {
+		log.SetOutput(ioutil.Discard)
 	}
 
 	var config *codegen.Config

--- a/neelance/introspection/introspection.go
+++ b/neelance/introspection/introspection.go
@@ -16,40 +16,40 @@ func WrapSchema(schema *schema.Schema) *Schema {
 	return &Schema{schema}
 }
 
-func (r *Schema) Types() []*Type {
+func (r *Schema) Types() []Type {
 	var names []string
 	for name := range r.schema.Types {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
-	l := make([]*Type, len(names))
+	l := make([]Type, len(names))
 	for i, name := range names {
-		l[i] = &Type{r.schema.Types[name]}
+		l[i] = Type{r.schema.Types[name]}
 	}
 	return l
 }
 
-func (r *Schema) Directives() []*Directive {
+func (r *Schema) Directives() []Directive {
 	var names []string
 	for name := range r.schema.Directives {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
-	l := make([]*Directive, len(names))
+	l := make([]Directive, len(names))
 	for i, name := range names {
-		l[i] = &Directive{r.schema.Directives[name]}
+		l[i] = Directive{r.schema.Directives[name]}
 	}
 	return l
 }
 
-func (r *Schema) QueryType() *Type {
+func (r *Schema) QueryType() Type {
 	t, ok := r.schema.EntryPoints["query"]
 	if !ok {
-		return nil
+		return Type{}
 	}
-	return &Type{t}
+	return Type{t}
 }
 
 func (r *Schema) MutationType() *Type {
@@ -100,7 +100,7 @@ func (r *Type) Description() *string {
 	return nil
 }
 
-func (r *Type) Fields(includeDeprecated bool) []*Field {
+func (r *Type) Fields(includeDeprecated bool) []Field {
 	var fields schema.FieldList
 	switch t := r.typ.(type) {
 	case *schema.Object:
@@ -111,29 +111,29 @@ func (r *Type) Fields(includeDeprecated bool) []*Field {
 		return nil
 	}
 
-	var l []*Field
+	var l []Field
 	for _, f := range fields {
 		if d := f.Directives.Get("deprecated"); d == nil || includeDeprecated {
-			l = append(l, &Field{f})
+			l = append(l, Field{f})
 		}
 	}
 	return l
 }
 
-func (r *Type) Interfaces() []*Type {
+func (r *Type) Interfaces() []Type {
 	t, ok := r.typ.(*schema.Object)
 	if !ok {
 		return nil
 	}
 
-	l := make([]*Type, len(t.Interfaces))
+	l := make([]Type, len(t.Interfaces))
 	for i, intf := range t.Interfaces {
-		l[i] = &Type{intf}
+		l[i] = Type{intf}
 	}
 	return l
 }
 
-func (r *Type) PossibleTypes() []*Type {
+func (r *Type) PossibleTypes() []Type {
 	var possibleTypes []*schema.Object
 	switch t := r.typ.(type) {
 	case *schema.Interface:
@@ -144,37 +144,37 @@ func (r *Type) PossibleTypes() []*Type {
 		return nil
 	}
 
-	l := make([]*Type, len(possibleTypes))
+	l := make([]Type, len(possibleTypes))
 	for i, intf := range possibleTypes {
-		l[i] = &Type{intf}
+		l[i] = Type{intf}
 	}
 	return l
 }
 
-func (r *Type) EnumValues(includeDeprecated bool) []*EnumValue {
+func (r *Type) EnumValues(includeDeprecated bool) []EnumValue {
 	t, ok := r.typ.(*schema.Enum)
 	if !ok {
 		return nil
 	}
 
-	var l []*EnumValue
+	var l []EnumValue
 	for _, v := range t.Values {
 		if d := v.Directives.Get("deprecated"); d == nil || includeDeprecated {
-			l = append(l, &EnumValue{v})
+			l = append(l, EnumValue{v})
 		}
 	}
 	return l
 }
 
-func (r *Type) InputFields() []*InputValue {
+func (r *Type) InputFields() []InputValue {
 	t, ok := r.typ.(*schema.InputObject)
 	if !ok {
 		return nil
 	}
 
-	l := make([]*InputValue, len(t.Values))
+	l := make([]InputValue, len(t.Values))
 	for i, v := range t.Values {
-		l[i] = &InputValue{v}
+		l[i] = InputValue{v}
 	}
 	return l
 }
@@ -205,16 +205,16 @@ func (r *Field) Description() *string {
 	return &r.field.Desc
 }
 
-func (r *Field) Args() []*InputValue {
-	l := make([]*InputValue, len(r.field.Args))
+func (r *Field) Args() []InputValue {
+	l := make([]InputValue, len(r.field.Args))
 	for i, v := range r.field.Args {
-		l[i] = &InputValue{v}
+		l[i] = InputValue{v}
 	}
 	return l
 }
 
-func (r *Field) Type() *Type {
-	return &Type{r.field.Type}
+func (r *Field) Type() Type {
+	return Type{r.field.Type}
 }
 
 func (r *Field) IsDeprecated() bool {
@@ -245,8 +245,8 @@ func (r *InputValue) Description() *string {
 	return &r.value.Desc
 }
 
-func (r *InputValue) Type() *Type {
-	return &Type{r.value.Type}
+func (r *InputValue) Type() Type {
+	return Type{r.value.Type}
 }
 
 func (r *InputValue) DefaultValue() *string {
@@ -304,10 +304,10 @@ func (r *Directive) Locations() []string {
 	return r.directive.Locs
 }
 
-func (r *Directive) Args() []*InputValue {
-	l := make([]*InputValue, len(r.directive.Args))
+func (r *Directive) Args() []InputValue {
+	l := make([]InputValue, len(r.directive.Args))
 	for i, v := range r.directive.Args {
-		l[i] = &InputValue{v}
+		l[i] = InputValue{v}
 	}
 	return l
 }

--- a/test/models-go/element.go
+++ b/test/models-go/element.go
@@ -3,3 +3,7 @@ package models
 type Element struct {
 	ID int
 }
+
+func (e *Element) Mismatched() []Element {
+	return []Element{*e}
+}

--- a/test/resolvers_test.go
+++ b/test/resolvers_test.go
@@ -142,6 +142,10 @@ func (r *testResolvers) Element_error(ctx context.Context, obj *models.Element) 
 	return false, r.err
 }
 
+func (r *testResolvers) Element_mismatched(ctx context.Context, obj *models.Element) ([]bool, error) {
+	return []bool{true}, nil
+}
+
 func (r *testResolvers) User_likes(ctx context.Context, obj *remote_api.User) ([]string, error) {
 	return obj.Likes, nil
 }

--- a/test/schema.graphql
+++ b/test/schema.graphql
@@ -1,6 +1,7 @@
 type Element {
     child: Element!
     error: Boolean!
+    mismatched: [Boolean!]
 }
 
 enum DATE_FILTER_OP {
@@ -19,8 +20,8 @@ input DateFilter {
 }
 
 type User {
-    name: String
-    likes: [String]
+    name: String!
+    likes: [String!]!
 }
 
 type Viewer {


### PR DESCRIPTION
Wow, this was bigger than I thought it would be.

Fixes a few type validation bugs when binding, and now returns proper error messages if binding fails for input types (its not possible to fall back to a resolver for inputs)

eg:
```
Unable to bind RecursiveInputSlice.self to github.com/vektah/gqlgen/codegen/testdata.RecursiveInputSlice
  no method named self
  field has wrong type: []github.com/vektah/gqlgen/codegen/testdata.RecursiveInputSlice is not compatible with *[]*github.com/vektah/gqlgen/codegen/testdata.RecursiveInputSlice
exec plan failed
```

These error messages can be shown for object types too, but they aren't errors because resolvers will be generated. If you run with gqlgen -v you will see why resolvers are being generated
eg:
```
example/scalars$ gqlgen -v
Unable to bind User.primitiveResolver to github.com/vektah/gqlgen/example/scalars/model.User
  no method named primitiveResolver
  no field named primitiveResolver
  Adding resolver method
Unable to bind User.customResolver to github.com/vektah/gqlgen/example/scalars/model.User
  no method named customResolver
  no field named customResolver
  Adding resolver method
example/scalars$ echo $?
0
```
Without the -v there will be no output.

fixes #162