### PR TITLE
Update playground version

### DIFF
--- a/handler/playground.go
+++ b/handler/playground.go
@@ -42,7 +42,7 @@ func Playground(title string, endpoint string) http.HandlerFunc {
 		err := page.Execute(w, map[string]string{
 			"title":    title,
 			"endpoint": endpoint,
-			"version":  "1.4.3",
+			"version":  "1.6.2",
 		})
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
The older version of GraphQL Playground has some issues with excessive CPU usage when idle:

- prismagraphql/graphql-playground#320
- prismagraphql/graphql-playground#569
- prismagraphql/graphql-playground#627
- prismagraphql/graphql-playground#653

Using the latest version (1.6.2) seems to fix the problem when I run it on my machine.