### PR TITLE
Use original credential for query request in playground

### DIFF
--- a/handler/playground.go
+++ b/handler/playground.go
@@ -30,6 +30,9 @@ var page = template.Must(template.New("graphiql").Parse(`<!DOCTYPE html>
 		GraphQLPlayground.init(root, {
 			endpoint: location.protocol + '//' + location.host + '{{.endpoint}}',
 			subscriptionsEndpoint: wsProto + '//' + location.host + '{{.endpoint }}',
+			settings: {
+				'request.credentials': 'same-origin'
+			}
 		})
 	})
 </script>


### PR DESCRIPTION
## Problem:
Currently the playground doesn't forward any credentials when making
query calls. This can cause problems if your playground requires login credentials.

## Solution:
Setting the request credential to "same-origin" fixes the issue.