### PR TITLE
Update gqlparser for validation locations

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -152,7 +152,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:3134a6c3595fe6ec84dc4fff02748d472d45af1ee3e1ffed31edca7dcb5ccad2"
+  digest = "1:3d316e2f86030258b422ad301fe5097a0e1ca80b264b82c02bd485d0db95341b"
   name = "github.com/vektah/gqlparser"
   packages = [
     ".",
@@ -164,7 +164,7 @@
     "validator/rules",
   ]
   pruneopts = "UT"
-  revision = "91afa0efa9d134b99ae434c16b5a43e71102b34b"
+  revision = "5f729223fc3d84c9bf65c2c9a7b1f708c1786d10"
 
 [[projects]]
   branch = "master"

--- a/handler/graphql_test.go
+++ b/handler/graphql_test.go
@@ -33,7 +33,7 @@ func TestHandlerPOST(t *testing.T) {
 	t.Run("validation failure", func(t *testing.T) {
 		resp := doRequest(h, "POST", "/graphql", `{"query": "{ me { title }}"}`)
 		assert.Equal(t, http.StatusUnprocessableEntity, resp.Code)
-		assert.Equal(t, `{"data":null,"errors":[{"message":"Cannot query field \"title\" on type \"User\"."}]}`, resp.Body.String())
+		assert.Equal(t, `{"data":null,"errors":[{"message":"Cannot query field \"title\" on type \"User\".","locations":[{"line":1,"column":8}]}]}`, resp.Body.String())
 	})
 
 	t.Run("execution failure", func(t *testing.T) {


### PR DESCRIPTION
Adds location back into validation error responses:

eg:
```
{"data":null,"errors":[{"message":"Cannot query field \"aa\" on type \"Todo\".","locations":[{"line":6,"column":5}]}]}
```